### PR TITLE
Fixed DTBS encoding handling.

### DIFF
--- a/src/main/java/fi/methics/laverca/rest/json/MSS_SignatureReq.java
+++ b/src/main/java/fi/methics/laverca/rest/json/MSS_SignatureReq.java
@@ -47,7 +47,7 @@ public class MSS_SignatureReq extends MSS_AbstractMessage {
         this.MobileUser.MSISDN = msisdn;
         
         this.DataToBeSigned = new Data();
-        this.DataToBeSigned.Data     = Base64.getEncoder().encodeToString(dtbs.toBytes());
+        this.DataToBeSigned.Data     = dtbs.getText();
         this.DataToBeSigned.Encoding = dtbs.getEncoding();
         this.DataToBeSigned.MimeType = dtbs.getMimetype();
         
@@ -88,8 +88,14 @@ public class MSS_SignatureReq extends MSS_AbstractMessage {
         
         public Data(DTBS dtbs) {
             if (dtbs != null) {
-                this.Data     = Base64.getEncoder().encodeToString(dtbs.toBytes());
-                this.Encoding = dtbs.getEncoding();
+                
+                if (dtbs.isData()) {
+                    this.Data     = Base64.getEncoder().encodeToString(dtbs.toBytes());
+                    this.Encoding = "BASE64";
+                } else {
+                    this.Data     = dtbs.getText();
+                    this.Encoding = dtbs.getEncoding();
+                }
                 this.MimeType = dtbs.getMimetype();
                 if (this.MimeType == null) {
                     this.MimeType = "text/plain";

--- a/src/main/java/fi/methics/laverca/rest/util/DTBS.java
+++ b/src/main/java/fi/methics/laverca/rest/util/DTBS.java
@@ -4,6 +4,7 @@
 package fi.methics.laverca.rest.util;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Dual-mode mapper class for "DataToBeSigned"
@@ -88,11 +89,21 @@ public class DTBS {
             return this.data;
         }
         if (this.text != null) {
-            try {
-                return this.text.getBytes(this.encoding);
+            if (this.encoding == null) {
+                return this.text.getBytes(StandardCharsets.UTF_8);
             }
-            catch (UnsupportedEncodingException uee) {
-                throw new RuntimeException(uee);
+            switch (this.encoding.toLowerCase()) {
+            case "base64":
+            case "hex": 
+                return this.text.getBytes(StandardCharsets.UTF_8);
+            }
+            
+            try {
+                // Try to use encoding as charset - for backwards compatibility
+                return this.text.getBytes(this.encoding);
+            } catch (UnsupportedEncodingException uee) {
+                // Default to UTF-8 if encoding is not a valid charset
+                return this.text.getBytes(StandardCharsets.UTF_8);
             }
         }
         throw new RuntimeException("Illegal DTBS");

--- a/src/main/java/fi/methics/laverca/rest/util/DTBS.java
+++ b/src/main/java/fi/methics/laverca/rest/util/DTBS.java
@@ -76,7 +76,23 @@ public class DTBS {
     public String  getText() { return this.text; }
     public byte[]  getData() { return this.data; }
 
-
+    /**
+     * Is this a data DTBS?
+     * @return true if data
+     */
+    public boolean isData() {
+        return this.data != null;
+    }
+    
+    /**
+     * Is this a text DTBS/DTBD?
+     * @return true if text
+     */
+    public boolean isText() {
+        return this.text != null;
+    }
+    
+    
     /**
      * Converter of incoming DTBS to byte-array, if the incoming
      * form happened to be a String, otherwise returning it as is.


### PR DESCRIPTION
 Encoding "base64" and "hex" were failing previously.

This approach should be backwards-compatible with cases that use a charset as encoding value.